### PR TITLE
The element should not float above all elements.

### DIFF
--- a/widget/pixi-grid.html
+++ b/widget/pixi-grid.html
@@ -12,7 +12,6 @@
 
       .labels {
         position: absolute;
-        z-index: 999;
 
         cursor: default;
         color: #999;
@@ -23,7 +22,7 @@
 
       #hlabels {
         bottom: 5px;
-        left: 0px;
+        left: 0;
       }
 
       #hlabels .label {
@@ -32,7 +31,7 @@
       }
 
       #vlabels {
-        top: 0px;
+        top: 0;
         left: 5px;
         /* -webkit-writing-mode: vertical-rl; */
         /* -webkit-text-orientation: upright; */
@@ -45,7 +44,6 @@
 
       .debug-info {
         position: absolute;
-        z-index: 999;
 
         top: 10px;
         right: 10px;


### PR DESCRIPTION
这两个元素被设置了z-index：999

这两个元素本身就浮动在canvas元素之上，设置了z-index的话，会将其他panel超出的元素遮盖掉。
